### PR TITLE
Rework init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astromonitor"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astromonitor"
-version = "0.4.1"
+version = "0.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
A bool was used to discriminate wether it was the first time the program was running
or was already a real check to see if kstars is alive.
Now the program checks immediately before starting the loop if we have kstars available
and the bool flag has no sense in this context.
Additionally we are preparing to use the process PID to work further and speed things up
when looking for processes.