### PR TITLE
feat: implement Phase 4 dashboard screen

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,6 @@
+use crate::backup::database::{retrieve_db, send_db};
 use astromonitor::config::{AppConfig, load_config, save_config};
+use astromonitor::Paths;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 
 pub enum SetupStep {
@@ -17,7 +19,9 @@ pub struct App {
     pub state: AppState,
     pub token_input: String,
     pub config: Option<AppConfig>,
-    pub confirm_focus: usize, // 0 = Confirm button, 1 = Cancel button
+    pub confirm_focus: usize,    // 0 = Confirm button, 1 = Cancel button
+    pub dashboard_focus: usize,  // 0 = Take Backup, 1 = Restore Backup
+    pub status_message: Option<(String, bool)>, // (message, is_success)
     pub running: bool,
 }
 
@@ -34,6 +38,8 @@ impl App {
             token_input: String::new(),
             config,
             confirm_focus: 0,
+            dashboard_focus: 0,
+            status_message: None,
             running: true,
         }
     }
@@ -110,9 +116,45 @@ impl App {
         }
 
         if matches!(self.state, AppState::Dashboard) {
-            // Phase 4 — placeholder quit handling
-            if key.code == KeyCode::Char('q') || key.code == KeyCode::Esc {
-                self.running = false;
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => {
+                    self.running = false;
+                }
+                KeyCode::Up => {
+                    if self.dashboard_focus > 0 {
+                        self.dashboard_focus -= 1;
+                    }
+                }
+                KeyCode::Down => {
+                    if self.dashboard_focus < 1 {
+                        self.dashboard_focus += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    let token = self
+                        .config
+                        .as_ref()
+                        .map(|c| c.token.clone())
+                        .unwrap_or_default();
+                    let paths = Paths::init();
+                    let result = if self.dashboard_focus == 0 {
+                        send_db(&paths, &token)
+                    } else {
+                        retrieve_db(&paths, &token)
+                    };
+                    self.status_message = Some(match result {
+                        Ok(_) => {
+                            let label = if self.dashboard_focus == 0 {
+                                "Backup completed successfully."
+                            } else {
+                                "Backup restored successfully."
+                            };
+                            (label.to_string(), true)
+                        }
+                        Err(e) => (format!("Error: {}", e), false),
+                    });
+                }
+                _ => {}
             }
         }
     }

--- a/src/tui/screens/dashboard.rs
+++ b/src/tui/screens/dashboard.rs
@@ -1,0 +1,119 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::tui::app::App;
+
+const BUTTONS: [&str; 2] = ["Take Backup", "Restore Backup"];
+
+pub fn render_dashboard(f: &mut Frame, app: &App) {
+    let area = f.size();
+
+    // Outer block with title
+    let outer_block = Block::default()
+        .title(" AstroMonitor 2.0 ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .style(Style::default().fg(Color::Cyan));
+    f.render_widget(outer_block, area);
+
+    // Inner area split: top (buttons) / bottom (hints + status)
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),    // spacer / buttons area
+            Constraint::Length(1), // status bar
+            Constraint::Length(1), // hint bar
+        ])
+        .split(inner);
+
+    // --- Buttons ---
+    render_buttons(f, app, chunks[0]);
+
+    // --- Status bar ---
+    let status_text = match &app.status_message {
+        Some((msg, true)) => Line::from(Span::styled(
+            format!(" {}", msg),
+            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+        )),
+        Some((msg, false)) => Line::from(Span::styled(
+            format!(" {}", msg),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )),
+        None => Line::from(""),
+    };
+    f.render_widget(Paragraph::new(status_text), chunks[1]);
+
+    // --- Hint bar ---
+    let hints = Paragraph::new(Line::from(vec![
+        Span::styled(" [↑↓] Navigate", Style::default().fg(Color::DarkGray)),
+        Span::styled("   [Enter] Select", Style::default().fg(Color::DarkGray)),
+        Span::styled("   [q] Quit", Style::default().fg(Color::DarkGray)),
+    ]));
+    f.render_widget(hints, chunks[2]);
+}
+
+fn render_buttons(f: &mut Frame, app: &App, area: Rect) {
+    // Stack buttons vertically in the center of the available area
+    let button_height: u16 = 3;
+    let gap: u16 = 1;
+    let total_height = BUTTONS.len() as u16 * button_height + (BUTTONS.len() as u16 - 1) * gap;
+    let button_width: u16 = 25;
+
+    let top_pad = area.height.saturating_sub(total_height) / 2;
+    let left_pad = area.width.saturating_sub(button_width) / 2;
+
+    for (i, label) in BUTTONS.iter().enumerate() {
+        let y = area.y + top_pad + i as u16 * (button_height + gap);
+        if y + button_height > area.y + area.height {
+            break;
+        }
+        let btn_area = Rect {
+            x: area.x + left_pad,
+            y,
+            width: button_width,
+            height: button_height,
+        };
+
+        let focused = app.dashboard_focus == i;
+        let (border_style, text_style) = if focused {
+            (
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else {
+            (
+                Style::default().fg(Color::White),
+                Style::default().fg(Color::White),
+            )
+        };
+
+        let block = Block::default().borders(Borders::ALL).style(border_style);
+        f.render_widget(Clear, btn_area);
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!("  {}  ", label),
+                text_style,
+            )))
+            .block(block)
+            .alignment(Alignment::Center),
+            btn_area,
+        );
+    }
+}

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,1 +1,2 @@
+pub mod dashboard;
 pub mod setup;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,14 +1,12 @@
 use ratatui::Frame;
 
 use super::app::{App, AppState};
-use super::screens::setup;
+use super::screens::{dashboard, setup};
 
 pub fn render(f: &mut Frame, app: &App) {
     match &app.state {
         AppState::Boot => {}
         AppState::Setup(_) => setup::render_setup(f, app),
-        AppState::Dashboard => {
-            // Implemented in Phase 4
-        }
+        AppState::Dashboard => dashboard::render_dashboard(f, app),
     }
 }


### PR DESCRIPTION
Adds the main action dashboard that users see after configuration:
- Two-button layout (Take Backup / Restore Backup) with focus highlight
- Up/Down arrow navigation between buttons
- Enter activates the focused button and calls the existing backup functions
- Status bar shows success or error message after each operation
- q/Esc quits cleanly

New file: src/tui/screens/dashboard.rs
Updated: src/tui/app.rs (dashboard_focus, status_message fields + key handling)
Updated: src/tui/screens/mod.rs (export dashboard module)
Updated: src/tui/ui.rs (wire render_dashboard into the render dispatch)