### PR TITLE
feat: implement Phase 5 — in-progress and result feedback screens

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,10 +9,17 @@ pub enum SetupStep {
     Confirm,
 }
 
+pub enum DashboardOp {
+    TakeBackup,
+    RestoreBackup,
+}
+
 pub enum AppState {
     Boot,
     Setup(SetupStep),
     Dashboard,
+    Working { label: String },
+    Result { message: String, success: bool },
 }
 
 pub struct App {
@@ -22,6 +29,7 @@ pub struct App {
     pub confirm_focus: usize,    // 0 = Confirm button, 1 = Cancel button
     pub dashboard_focus: usize,  // 0 = Take Backup, 1 = Restore Backup
     pub status_message: Option<(String, bool)>, // (message, is_success)
+    pub pending_op: Option<DashboardOp>,
     pub running: bool,
 }
 
@@ -40,6 +48,7 @@ impl App {
             confirm_focus: 0,
             dashboard_focus: 0,
             status_message: None,
+            pending_op: None,
             running: true,
         }
     }
@@ -131,31 +140,49 @@ impl App {
                     }
                 }
                 KeyCode::Enter => {
-                    let token = self
-                        .config
-                        .as_ref()
-                        .map(|c| c.token.clone())
-                        .unwrap_or_default();
-                    let paths = Paths::init();
-                    let result = if self.dashboard_focus == 0 {
-                        send_db(&paths, &token)
+                    let (op, label) = if self.dashboard_focus == 0 {
+                        (DashboardOp::TakeBackup, "Taking backup…")
                     } else {
-                        retrieve_db(&paths, &token)
+                        (DashboardOp::RestoreBackup, "Restoring backup…")
                     };
-                    self.status_message = Some(match result {
-                        Ok(_) => {
-                            let label = if self.dashboard_focus == 0 {
-                                "Backup completed successfully."
-                            } else {
-                                "Backup restored successfully."
-                            };
-                            (label.to_string(), true)
-                        }
-                        Err(e) => (format!("Error: {}", e), false),
-                    });
+                    self.pending_op = Some(op);
+                    self.state = AppState::Working {
+                        label: label.to_string(),
+                    };
                 }
                 _ => {}
             }
+            return;
+        }
+
+        if matches!(self.state, AppState::Result { .. }) {
+            self.state = AppState::Dashboard;
+        }
+    }
+
+    /// Execute the pending backup/restore operation and transition to Result.
+    /// Called by the runner after the Working frame has been drawn.
+    pub fn execute_pending_op(&mut self) {
+        if let Some(op) = self.pending_op.take() {
+            let token = self
+                .config
+                .as_ref()
+                .map(|c| c.token.clone())
+                .unwrap_or_default();
+            let paths = Paths::init();
+            let (result, success_msg) = match &op {
+                DashboardOp::TakeBackup => {
+                    (send_db(&paths, &token), "Backup completed successfully.")
+                }
+                DashboardOp::RestoreBackup => {
+                    (retrieve_db(&paths, &token), "Backup restored successfully.")
+                }
+            };
+            let (message, success) = match result {
+                Ok(_) => (success_msg.to_string(), true),
+                Err(e) => (format!("Error: {}", e), false),
+            };
+            self.state = AppState::Result { message, success };
         }
     }
 }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -8,7 +8,7 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 
-use super::app::App;
+use super::app::{App, AppState};
 use super::ui;
 
 pub fn run() -> Result<(), Box<dyn Error>> {
@@ -23,6 +23,15 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     let result = (|| -> Result<(), Box<dyn Error>> {
         while app.running {
             terminal.draw(|f| ui::render(f, &app))?;
+
+            // If we are in the Working state, run the operation synchronously
+            // (the Working frame has already been drawn above) then loop again
+            // to draw the Result frame without consuming a key event.
+            if matches!(app.state, AppState::Working { .. }) {
+                app.execute_pending_op();
+                continue;
+            }
+
             if let Event::Key(key) = event::read()? {
                 app.handle_key(key);
             }

--- a/src/tui/screens/feedback.rs
+++ b/src/tui/screens/feedback.rs
@@ -1,0 +1,93 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+pub fn render_working(f: &mut Frame, label: &str) {
+    let area = f.size();
+
+    let outer_block = Block::default()
+        .title(" AstroMonitor 2.0 ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .style(Style::default().fg(Color::Cyan));
+    f.render_widget(outer_block, area);
+
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(45),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Percentage(45),
+        ])
+        .split(ratatui::layout::Rect {
+            x: area.x + 1,
+            y: area.y + 1,
+            width: area.width.saturating_sub(2),
+            height: area.height.saturating_sub(2),
+        });
+
+    let spinner = Paragraph::new(Line::from(Span::styled(
+        "⠿  Working…",
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(spinner, inner[1]);
+
+    let detail = Paragraph::new(Line::from(Span::styled(
+        label,
+        Style::default().fg(Color::DarkGray),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(detail, inner[2]);
+}
+
+pub fn render_result(f: &mut Frame, message: &str, success: bool) {
+    let area = f.size();
+
+    let outer_block = Block::default()
+        .title(" AstroMonitor 2.0 ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .style(Style::default().fg(Color::Cyan));
+    f.render_widget(outer_block, area);
+
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(40),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Percentage(40),
+            Constraint::Length(1),
+        ])
+        .split(ratatui::layout::Rect {
+            x: area.x + 1,
+            y: area.y + 1,
+            width: area.width.saturating_sub(2),
+            height: area.height.saturating_sub(2),
+        });
+
+    let color = if success { Color::Green } else { Color::Red };
+    let icon = if success { "✓" } else { "✗" };
+
+    let result_line = Paragraph::new(Line::from(Span::styled(
+        format!("{}  {}", icon, message),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(result_line, inner[1]);
+
+    let hint = Paragraph::new(Line::from(Span::styled(
+        "Press any key to return to Dashboard",
+        Style::default().fg(Color::DarkGray),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(hint, inner[2]);
+}

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,2 +1,3 @@
 pub mod dashboard;
+pub mod feedback;
 pub mod setup;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,12 +1,14 @@
 use ratatui::Frame;
 
 use super::app::{App, AppState};
-use super::screens::{dashboard, setup};
+use super::screens::{dashboard, feedback, setup};
 
 pub fn render(f: &mut Frame, app: &App) {
     match &app.state {
         AppState::Boot => {}
         AppState::Setup(_) => setup::render_setup(f, app),
         AppState::Dashboard => dashboard::render_dashboard(f, app),
+        AppState::Working { label } => feedback::render_working(f, label),
+        AppState::Result { message, success } => feedback::render_result(f, message, *success),
     }
 }


### PR DESCRIPTION
Add AppState::Working and AppState::Result to the TUI state machine.
When a backup or restore is triggered from the Dashboard, the app now
transitions to a Working screen (drawn before the blocking HTTP call),
executes the operation on the same thread, then transitions to a Result
screen showing success or failure. Any key on the Result screen returns
to the Dashboard.

New files:
- src/tui/screens/feedback.rs — render_working / render_result

Changed files:
- src/tui/app.rs — DashboardOp enum, Working/Result variants, pending_op
  field, execute_pending_op(), Result key handler
- src/tui/runner.rs — detect Working state, execute op without blocking
  on a key event
- src/tui/screens/mod.rs — expose feedback module
- src/tui/ui.rs — dispatch Working/Result to feedback render functions