### PR TITLE
feat: Phase 6 — polish and cleanup for 2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## Project Overview
 
-**astromonitor** is a Rust-based CLI watchdog tool for amateur astronomers using [KStars](https://kstars.kde.org/) astronomy software. It monitors the KStars process, sends crash notifications via Telegram, logs system resource usage, and manages backup/restore of astronomy configuration files.
+**astromonitor** is a Rust-based TUI application for amateur astronomers using [KStars](https://kstars.kde.org/) astronomy software. It provides an interactive terminal dashboard to back up and restore astronomy configuration files, with Telegram integration for notifications.
 
 - **Language:** Rust (Edition 2021)
 - **Binary name:** `astromonitor`
-- **Version:** 1.1.0
+- **Version:** 2.0.0
 - **Supported platforms:** Linux (AMD64, ARM64/Raspberry Pi), macOS (Intel, Apple Silicon)
 
 ---
@@ -17,18 +17,30 @@
 astro_monitor/
 ├── .github/workflows/build-check.yml   # CI/CD: multi-target build and release
 ├── src/
-│   ├── main.rs                         # CLI entry point, orchestration, Telegram notify
-│   ├── lib.rs                          # Core types: CliArgs, Paths, constants
+│   ├── main.rs                         # Entry point: calls tui::runner::run()
+│   ├── lib.rs                          # Core types: Paths, HOST constant
+│   ├── config.rs                       # AppConfig load/save (astro.json)
 │   ├── backup/
 │   │   ├── mod.rs                      # Module re-exports
 │   │   └── database.rs                 # Backup upload and restore logic
 │   ├── checks/
 │   │   ├── mod.rs                      # Module re-exports
-│   │   ├── system.rs                   # lsof detection
+│   │   ├── system.rs                   # lsof detection (reserved for future TUI use)
 │   │   └── vault.rs                    # Log directory initialization
-│   └── monitoring/
-│       ├── mod.rs                      # Module re-exports
-│       └── resources.rs                # CPU/RAM logging
+│   ├── monitoring/
+│   │   ├── mod.rs                      # Module re-exports
+│   │   ├── resources.rs                # CPU/RAM logging (reserved for future TUI use)
+│   │   └── telegram.rs                 # Telegram notification helper
+│   └── tui/
+│       ├── mod.rs                      # TUI module root
+│       ├── app.rs                      # App struct, AppState enum, input handling
+│       ├── runner.rs                   # Terminal init, main event loop
+│       ├── ui.rs                       # Top-level render dispatcher
+│       └── screens/
+│           ├── mod.rs                  # Screen module re-exports
+│           ├── setup.rs                # First-run setup wizard screens
+│           ├── dashboard.rs            # Main action dashboard
+│           └── feedback.rs            # Working / Result screens
 ├── Cargo.toml                          # Rust project manifest and dependencies
 ├── Cargo.lock                          # Locked dependency versions
 ├── install.sh                          # End-user install script
@@ -39,19 +51,49 @@ astro_monitor/
 
 ## Key Architecture
 
-### CLI Structure (`src/lib.rs`, `src/main.rs`)
+### TUI Structure (`src/tui/`)
 
-The `CliArgs` struct (via `structopt`) defines all CLI flags:
-- `--kstars <TOKEN>` — monitor KStars process; send Telegram alert on crash
-- `--do-backup <TOKEN>` — create TAR archive of astronomy configs and upload to server
-- `--retrieve-backup <TOKEN>` — download and restore backed-up configs
-- `--fd-monitor` — log open file descriptors (requires `lsof` on PATH)
-- `--system-monitor` — periodically log CPU/RAM usage to timestamped files
+The application is fully driven by a `ratatui`/`crossterm` Terminal UI. There are no CLI flags.
 
-All features requiring a token use a Telegram bot (`@AstroMonitorBot`) for authentication and notifications.
+**Application states (`src/tui/app.rs`)**:
+
+```
+AppState::Boot
+    │
+    ├─ config exists ──► AppState::Dashboard
+    │
+    └─ config missing ──► AppState::Setup(SetupStep::Instructions)
+                               │
+                               └─► AppState::Setup(SetupStep::TokenEntry)
+                                        │
+                                        └─► AppState::Setup(SetupStep::Confirm)
+                                                 │
+                                                 ├─ confirmed ──► (save) ──► AppState::Dashboard
+                                                 └─ cancelled ──► AppState::Setup(SetupStep::TokenEntry)
+
+AppState::Dashboard ──► AppState::Working { label } ──► AppState::Result { message, success }
+                                                               │
+                                                               └─► AppState::Dashboard (any key)
+```
+
+- `App::new()` loads the config to determine initial state.
+- `App::handle_key()` dispatches key events to the active state handler.
+- `App::execute_pending_op()` runs the backup/restore synchronously after the Working frame is drawn.
+
+### Config File (`src/config.rs`)
+
+**Path:** `~/.config/astromonitor/astro.json`
+
+```json
+{
+  "token": "<telegram bot token>"
+}
+```
+
+- `load_config() -> Option<AppConfig>` — reads and deserializes; returns `None` on missing/malformed file
+- `save_config(config: &AppConfig) -> Result<(), String>` — creates directory if needed, writes JSON
 
 ### Key Constants (`src/lib.rs`)
-- `INTERVAL = 15` — polling interval in seconds for process/resource monitoring
 - `HOST = "http://astromatto.com:11111"` — hardcoded backup/notification server
 
 ### Cross-platform Paths (`src/lib.rs` — `Paths` struct)
@@ -85,8 +127,7 @@ cargo build
 cargo build --release
 
 # Run directly
-cargo run -- --help
-cargo run -- --kstars <TOKEN>
+cargo run
 ```
 
 ### Cross-compilation (matches CI targets)
@@ -110,7 +151,7 @@ cargo build --release --target aarch64-unknown-linux-gnu
 
 The `env_logger` crate reads the `ASTROMONITOR_LOG_LEVEL` environment variable:
 ```bash
-ASTROMONITOR_LOG_LEVEL=debug cargo run -- --system-monitor
+ASTROMONITOR_LOG_LEVEL=debug cargo run
 ```
 Default level is `info`. Use `error`, `warn`, `info`, `debug`, or `trace`.
 
@@ -175,8 +216,11 @@ When adding tests:
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `structopt` | 0.3 | CLI argument parsing |
-| `sysinfo` | 0.27 | CPU, RAM, process info |
+| `ratatui` | 0.26 | Terminal UI framework |
+| `crossterm` | 0.27 | Cross-platform terminal backend and input events |
+| `serde` | 1 | Serialization/deserialization (derive macros) |
+| `serde_json` | 1 | JSON config file format |
+| `sysinfo` | 0.27 | CPU, RAM, process info (reserved for future TUI panels) |
 | `minreq` | 2.6 | HTTP client (with TLS for Telegram/backup API) |
 | `tar` | 0.4 | TAR archive creation and extraction |
 | `chrono` | 0.4 | Timestamp formatting for log files |
@@ -209,8 +253,8 @@ When adding tests:
 1. **No test suite exists** — changes cannot be validated by running tests. Reason carefully about correctness.
 2. **The backup server URL is hardcoded** — `http://astromatto.com:11111`. Any change here affects all users.
 3. **Cross-platform paths are critical** — always use the `Paths` struct rather than hardcoded paths to ensure Linux/macOS compatibility.
-4. **The polling loop in `main.rs`** uses `std::thread::sleep(Duration::from_secs(INTERVAL))`. Changes to monitoring logic should preserve this pattern.
+4. **No CLI flags** — version 2.0 is entirely TUI-driven. Do not re-introduce `structopt` or `clap` unless asked.
 5. **No async runtime** — the project is fully synchronous. Do not introduce `tokio` or `async-std` without strong justification.
 6. **`Cargo.lock` is committed** — this is a binary application, so the lock file should stay tracked in git.
 7. **CI targets ARM** — avoid `x86_64`-only APIs or system calls; test cross-compilation when adding system-level features.
-8. **`structopt` is legacy** — it wraps `clap` v2. New CLI projects should use `clap` v4 directly, but do not migrate this unless asked.
+8. **`checks/` and `monitoring/` modules are preserved** — they are kept for potential future TUI panels (e.g. system resource monitor, fd monitor) but are not wired into the TUI yet.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "astromonitor"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "crossterm",
@@ -39,7 +39,6 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
- "structopt",
  "sysinfo",
  "tar",
 ]
@@ -108,17 +107,6 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -366,15 +354,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -643,30 +622,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -952,30 +907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,7 +921,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1052,15 +983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1128,12 +1050,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astromonitor"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 minreq = { version = "2.6", features = ["https"] }
 sysinfo = "0.27"
-structopt = { version = "0.3", default-features = false }
 dirs = "4.0"
 chrono = "0.4"
 tar = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,58 +4,72 @@
 </p>
 
 
-A small program that can help you with your astro session. 
-The main functionality is the watchdog; if astromonitor notices Kstars is dead il will send a request to notify you via telegram. 
-The other cool feature is the backup, astromonitor can backup:
-- your INDI configuration for your devices
-- the profile containing your equipment and setup
-- PHD2 profile
-- generic Kstars option (theme, colors, etc.)
+A small program that can help you with your astro session.
+AstroMonitor can backup your astronomy configuration files and restore them on any machine:
+- INDI device profiles
+- KStars equipment profile and user database
+- PHD2 guide profile
+- KStars settings (theme, colors, etc.)
 
-  
-you can restore the backup on an other PC or when installing the suite again.
-
-# Have a look at how it works
-https://github.com/MattBlack85/astro_monitor/assets/4163222/587784c4-6a9b-4485-9444-9d0d61d9897e
+You can restore the backup on another PC or after a fresh install.
 
 # Install
-you trust me? run the following command
+Trust me? Run the following command:
 
 ```shell
 wget -O - https://raw.githubusercontent.com/MattBlack85/astro_monitor/main/install.sh | sh
 ```
 
-sudo will be needed as last step to move `astromonitor` to `/usr/local/bin`
+`sudo` is needed at the last step to move `astromonitor` to `/usr/local/bin`.
 
+# How to use AstroMonitor
 
-# How to use astromonitor
-Using astromonitor is easy, just follow these instruction
+AstroMonitor 2.0 features a fully interactive Terminal UI — no flags needed.
 
-## First step - obtain a token using telegram
-On telegram, look for @AstroMonitorBot (the icon is the bubble nebula from hubble) and send a `/register` command, it will answer with a token, store it in a safe place, that's your key for the backups.
+## First launch (no config found)
 
-## Make a backup
-Open a terminal and run `astromonitor --do-backup XXXXXXXXXXXXXXXXXX` paste your key obtained in the previous step instead of XXXXXXXXXX
+1. Run `astromonitor` in a terminal.
+2. The setup wizard appears automatically.
+3. Follow the on-screen instructions: open Telegram, search for `@AstroMonitorBot`, send `/register`, and copy the token you receive.
+4. Enter the token when prompted, then confirm.
+5. Your token is saved to `~/.config/astromonitor/astro.json` — you won't need to enter it again.
 
-## Retrieve a previously made backup
-Open a terminal and run `astromonitor --retrieve-backup XXXXXXXXXXXXXXXXXX` paste your key obtained in the previous step instead of XXXXXXXXXX
+## Dashboard
 
-## Monitor Kstars during a session
-Open a terminal and run `astromonitor --kstars XXXXXXXXXXXXXXXXXX` paste your key obtained in the previous step instead of XXXXXXXXXX
+After setup (or on every subsequent launch) you land on the main dashboard:
 
-This will start monitoring Kstars and if it crashes, it will send you a notification via telegram
+```
+┌─────────────────────────────────────────────────┐
+│           AstroMonitor 2.0                      │
+├─────────────────────────────────────────────────┤
+│                                                 │
+│      ┌─────────────────┐                        │
+│      │   Take Backup   │  ← focused             │
+│      └─────────────────┘                        │
+│                                                 │
+│      ┌─────────────────┐                        │
+│      │ Restore Backup  │                        │
+│      └─────────────────┘                        │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│  [↑↓] Navigate   [Enter] Select   [q] Quit      │
+└─────────────────────────────────────────────────┘
+```
 
-# List of all functionalities:
-you can obtain the same list by running `astromonitor --help`, here what we actually support:
+- **↑ / ↓** — move focus between buttons
+- **Enter** — run the selected operation
+- **q** or **Esc** — quit
 
-- `--kstars` monitor Kstars and send a telegram notification if it crashes during a session
-- `--do-backup` make a backup of the Kstars database and INDI devices configuration and store it remotely
-- `--retrieve-backup` restore the previously saved backup
-- `--fd-monitor` monitor file descriptors used to check if there is any leak
-- `--system-monitor` monitor system resources (CPU and RAM) usage and log it
+A status bar shows the result of each operation (success or error).
 
-The main folder where you'll find the logs is `~/.local/share/astromonitor/logs`
+# Compile it yourself
 
-# Compile it and run
-If you want to compile it by yourself, the project is pure `Rust`, you just need the rust toolchain (see https://rustup.rs/), then clone this repo with `git clone https://github.com/MattBlack85/astro_monitor` or `git clone git@github.com:MattBlack85/astro_monitor` cd into the folder `cd astro_monitor` and then `cargo build --release`.
-You will find the compiled program then under `target/release/astromonitor` you can move the program around (for example /usr/local/bin)
+The project is pure Rust. Install the toolchain from [rustup.rs](https://rustup.rs/), then:
+
+```shell
+git clone https://github.com/MattBlack85/astro_monitor
+cd astro_monitor
+cargo build --release
+```
+
+The compiled binary is at `target/release/astromonitor`. Move it wherever you like (e.g. `/usr/local/bin`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,8 @@
 use std::path::PathBuf;
-use std::time;
-use structopt::StructOpt;
 
 pub mod config;
 
-pub static INTERVAL: time::Duration = time::Duration::from_secs(15);
 pub static HOST: &'static str = "http://astromatto.com:11111";
-
-#[derive(StructOpt)]
-pub struct CliArgs {
-    pub api_token: String,
-    #[structopt(long)]
-    pub fd_monitor: bool,
-    #[structopt(long)]
-    pub system_monitor: bool,
-    #[structopt(long)]
-    pub do_backup: bool,
-    #[structopt(long)]
-    pub retrieve_backup: bool,
-    #[structopt(long)]
-    pub kstars: bool,
-}
 
 pub struct Paths {
     folder_path: String,


### PR DESCRIPTION
- Remove CliArgs struct and structopt dependency (no CLI flags in 2.0)
- Bump version to 2.0.0
- Rewrite README.md to describe the TUI flow instead of CLI flags
- Update CLAUDE.md to reflect the 2.0 architecture and dependencies