### PR TITLE
feat: re-add KStars watchdog as 2.0 TUI feature

### DIFF
--- a/src/checks/system.rs
+++ b/src/checks/system.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use sysinfo::{System, SystemExt};
 
 pub fn lsof_on_system() -> bool {
     let result = Command::new("which").arg("lsof").output().expect("error");
@@ -9,4 +10,12 @@ pub fn lsof_on_system() -> bool {
         "" => return false,
         _ => return true,
     };
+}
+
+/// Returns true if a process named "kstars" is currently running.
+pub fn kstars_is_running() -> bool {
+    let mut system = System::new();
+    system.refresh_processes();
+    let found = system.processes_by_exact_name("kstars").next().is_some();
+    found
 }

--- a/src/monitoring/telegram.rs
+++ b/src/monitoring/telegram.rs
@@ -21,3 +21,22 @@ pub fn notify_via_telegram(token: &String) {
         }
     }
 }
+
+/// Send a KStars-stopped alert via Telegram without exiting the process.
+/// Returns Ok(()) on HTTP 200, Err with a description otherwise.
+pub fn send_kstars_alert(token: &str) -> Result<(), String> {
+    match minreq::post(format!("{}/hook/{}", HOST, token)).send() {
+        Ok(r) if r.status_code == 200 => {
+            info!("KStars alert sent successfully.");
+            Ok(())
+        }
+        Ok(r) => {
+            warn!("KStars alert: unexpected status {}", r.status_code);
+            Err(format!("HTTP status {}", r.status_code))
+        }
+        Err(e) => {
+            error!("KStars alert: request failed: {}", e);
+            Err(e.to_string())
+        }
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,9 @@
 use crate::backup::database::{retrieve_db, send_db};
+use crate::checks::system::kstars_is_running;
+use crate::monitoring::telegram::send_kstars_alert;
 use astromonitor::config::{AppConfig, load_config, save_config};
 use astromonitor::Paths;
+use chrono::SecondsFormat;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 
 pub enum SetupStep {
@@ -20,6 +23,7 @@ pub enum AppState {
     Dashboard,
     Working { label: String },
     Result { message: String, success: bool },
+    KStarsMonitor { started_at: String, last_seen_at: String },
 }
 
 pub struct App {
@@ -135,28 +139,80 @@ impl App {
                     }
                 }
                 KeyCode::Down => {
-                    if self.dashboard_focus < 1 {
+                    if self.dashboard_focus < 2 {
                         self.dashboard_focus += 1;
                     }
                 }
-                KeyCode::Enter => {
-                    let (op, label) = if self.dashboard_focus == 0 {
-                        (DashboardOp::TakeBackup, "Taking backup…")
-                    } else {
-                        (DashboardOp::RestoreBackup, "Restoring backup…")
-                    };
-                    self.pending_op = Some(op);
-                    self.state = AppState::Working {
-                        label: label.to_string(),
-                    };
-                }
+                KeyCode::Enter => match self.dashboard_focus {
+                    0 => {
+                        self.pending_op = Some(DashboardOp::TakeBackup);
+                        self.state = AppState::Working {
+                            label: "Taking backup…".to_string(),
+                        };
+                    }
+                    1 => {
+                        self.pending_op = Some(DashboardOp::RestoreBackup);
+                        self.state = AppState::Working {
+                            label: "Restoring backup…".to_string(),
+                        };
+                    }
+                    2 => self.start_kstars_monitor(),
+                    _ => {}
+                },
                 _ => {}
+            }
+            return;
+        }
+
+        if matches!(self.state, AppState::KStarsMonitor { .. }) {
+            if key.code == KeyCode::Char('q') || key.code == KeyCode::Esc {
+                self.state = AppState::Dashboard;
             }
             return;
         }
 
         if matches!(self.state, AppState::Result { .. }) {
             self.state = AppState::Dashboard;
+        }
+    }
+
+    /// Check if KStars is running and enter KStarsMonitor state, or show an error.
+    fn start_kstars_monitor(&mut self) {
+        if kstars_is_running() {
+            let now = chrono::Local::now().to_rfc3339_opts(SecondsFormat::Secs, false);
+            self.state = AppState::KStarsMonitor {
+                started_at: now.clone(),
+                last_seen_at: now,
+            };
+        } else {
+            self.state = AppState::Result {
+                message: "KStars is not running. Please start KStars first.".to_string(),
+                success: false,
+            };
+        }
+    }
+
+    /// Called on each watchdog tick. Checks the KStars process and notifies if it stopped.
+    pub fn tick_kstars_monitor(&mut self) {
+        if kstars_is_running() {
+            let now = chrono::Local::now().to_rfc3339_opts(SecondsFormat::Secs, false);
+            if let AppState::KStarsMonitor { ref mut last_seen_at, .. } = self.state {
+                *last_seen_at = now;
+            }
+        } else {
+            let token = self
+                .config
+                .as_ref()
+                .map(|c| c.token.clone())
+                .unwrap_or_default();
+            let message = match send_kstars_alert(&token) {
+                Ok(_) => "KStars stopped. Telegram notification sent.".to_string(),
+                Err(e) => format!("KStars stopped. Notification failed: {}", e),
+            };
+            self.state = AppState::Result {
+                message,
+                success: true,
+            };
         }
     }
 

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::io;
+use std::time::Duration;
 
 use crossterm::{
     event::{self, Event},
@@ -10,6 +11,9 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 
 use super::app::{App, AppState};
 use super::ui;
+
+/// How often the KStars watchdog checks the process list.
+const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 pub fn run() -> Result<(), Box<dyn Error>> {
     enable_raw_mode()?;
@@ -29,6 +33,19 @@ pub fn run() -> Result<(), Box<dyn Error>> {
             // to draw the Result frame without consuming a key event.
             if matches!(app.state, AppState::Working { .. }) {
                 app.execute_pending_op();
+                continue;
+            }
+
+            // In KStarsMonitor state, use a timed poll so the watchdog can tick
+            // periodically even when the user presses no keys.
+            if matches!(app.state, AppState::KStarsMonitor { .. }) {
+                if event::poll(WATCHDOG_POLL_INTERVAL)? {
+                    if let Event::Key(key) = event::read()? {
+                        app.handle_key(key);
+                    }
+                } else {
+                    app.tick_kstars_monitor();
+                }
                 continue;
             }
 

--- a/src/tui/screens/dashboard.rs
+++ b/src/tui/screens/dashboard.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::tui::app::App;
 
-const BUTTONS: [&str; 2] = ["Take Backup", "Restore Backup"];
+const BUTTONS: [&str; 3] = ["Take Backup", "Restore Backup", "Watch KStars"];
 
 pub fn render_dashboard(f: &mut Frame, app: &App) {
     let area = f.size();

--- a/src/tui/screens/feedback.rs
+++ b/src/tui/screens/feedback.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
@@ -46,6 +46,66 @@ pub fn render_working(f: &mut Frame, label: &str) {
     )))
     .alignment(Alignment::Center);
     f.render_widget(detail, inner[2]);
+}
+
+pub fn render_kstars_monitor(f: &mut Frame, started_at: &str, last_seen_at: &str) {
+    let area = f.size();
+
+    let outer_block = Block::default()
+        .title(" AstroMonitor 2.0 — KStars Watchdog ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .style(Style::default().fg(Color::Cyan));
+    f.render_widget(outer_block, area);
+
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let status = Paragraph::new(Line::from(Span::styled(
+        "● Watching KStars process…",
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(status, chunks[1]);
+
+    let started = Paragraph::new(Line::from(Span::styled(
+        format!("Started:    {}", started_at),
+        Style::default().fg(Color::DarkGray),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(started, chunks[2]);
+
+    let last_seen = Paragraph::new(Line::from(Span::styled(
+        format!("Last seen:  {}", last_seen_at),
+        Style::default().fg(Color::DarkGray),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(last_seen, chunks[3]);
+
+    let hint = Paragraph::new(Line::from(Span::styled(
+        "[q / Esc] Stop watching",
+        Style::default().fg(Color::DarkGray),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(hint, chunks[5]);
 }
 
 pub fn render_result(f: &mut Frame, message: &str, success: bool) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,5 +10,8 @@ pub fn render(f: &mut Frame, app: &App) {
         AppState::Dashboard => dashboard::render_dashboard(f, app),
         AppState::Working { label } => feedback::render_working(f, label),
         AppState::Result { message, success } => feedback::render_result(f, message, *success),
+        AppState::KStarsMonitor { started_at, last_seen_at } => {
+            feedback::render_kstars_monitor(f, started_at, last_seen_at)
+        }
     }
 }


### PR DESCRIPTION
Adds a Watch KStars button to the dashboard. When selected it checks
whether KStars is already running (exits to a result screen if not),
then enters a KStarsMonitor state that polls the process list every 5
seconds. If KStars stops, a Telegram alert is sent via the existing
token and the user is shown a result screen.

Changes:
- src/checks/system.rs: add kstars_is_running() using sysinfo
- src/monitoring/telegram.rs: add send_kstars_alert() that returns
  Result instead of calling process::exit, for use inside the TUI
- src/tui/app.rs: add AppState::KStarsMonitor, DashboardOp navigation
  extended to 3 buttons, start_kstars_monitor() and tick_kstars_monitor()
- src/tui/runner.rs: use event::poll(5s) in KStarsMonitor state so the
  watchdog ticks without blocking on key input
- src/tui/screens/dashboard.rs: add Watch KStars third button
- src/tui/screens/feedback.rs: add render_kstars_monitor() screen
- src/tui/ui.rs: dispatch KStarsMonitor state to new render function