### PR TITLE
fix: use unique artifact names per matrix target to prevent upload conflicts

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Archive artifact
         uses: actions/upload-artifact@v4
         with:
-          name: result
+          name: result-${{ matrix.SHORT_NAME }}
           path: |
             ./artifacts
   # deploys to github releases on tag
@@ -109,10 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: result
           path: ./artifacts
+          merge-multiple: true
       - name: List
         run: find ./artifacts
       - name: Release


### PR DESCRIPTION
upload-artifact@v4 rejects concurrent uploads with the same name, causing
all but one matrix job to fail. Use result-{SHORT_NAME} per job and update
the deploy step to download-artifact@v4 with merge-multiple: true.

https://claude.ai/code/session_01N78obBCBpY9gN3f1n9zVhB